### PR TITLE
switch base image to openjdk buster-slim

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -19,7 +19,8 @@
     </modules>
 
     <properties>
-        <tesseract.version>3.04.*</tesseract.version>
+        <tesseract.version>4.0.0*</tesseract.version>
+        <tesseract.lang.version>1:4.00*</tesseract.lang.version>
 
         <!-- Global configuration parameters for docker -->
         <!-- By default, build docker images on each modules. -->
@@ -45,7 +46,7 @@
         <docker.eng.dockerFile>${docker.nolang.dockerFile}</docker.eng.dockerFile>
         <docker.eng.assembly.descriptor>${docker.nolang.assembly.descriptor}</docker.eng.assembly.descriptor>
         <docker.eng.assembly.mode>${docker.nolang.assembly.mode}</docker.eng.assembly.mode>
-        <docker.eng.args.langsPkg>tesseract-ocr=${tesseract.version} tesseract-ocr-eng=${tesseract.version}</docker.eng.args.langsPkg>
+        <docker.eng.args.langsPkg>tesseract-ocr=${tesseract.version} tesseract-ocr-eng=${tesseract.lang.version}</docker.eng.args.langsPkg>
 
         <!-- install tesseract-ocr and data files for French -->
         <docker.fra.alias>${project.artifactId}-fra</docker.fra.alias>
@@ -54,7 +55,7 @@
         <docker.fra.dockerFile>${docker.nolang.dockerFile}</docker.fra.dockerFile>
         <docker.fra.assembly.descriptor>${docker.nolang.assembly.descriptor}</docker.fra.assembly.descriptor>
         <docker.fra.assembly.mode>${docker.nolang.assembly.mode}</docker.fra.assembly.mode>
-        <docker.fra.args.langsPkg>tesseract-ocr=${tesseract.version} tesseract-ocr-fra=${tesseract.version}</docker.fra.args.langsPkg>
+        <docker.fra.args.langsPkg>tesseract-ocr=${tesseract.version} tesseract-ocr-fra=${tesseract.lang.version}</docker.fra.args.langsPkg>
 
         <!-- install tesseract-ocr and  data files for Japanese -->
         <docker.jpn.alias>${project.artifactId}-jpn</docker.jpn.alias>
@@ -63,7 +64,7 @@
         <docker.jpn.dockerFile>${docker.nolang.dockerFile}</docker.jpn.dockerFile>
         <docker.jpn.assembly.descriptor>${docker.nolang.assembly.descriptor}</docker.jpn.assembly.descriptor>
         <docker.jpn.assembly.mode>${docker.nolang.assembly.mode}</docker.jpn.assembly.mode>
-        <docker.jpn.args.langsPkg>tesseract-ocr=${tesseract.version} tesseract-ocr-jpn=${tesseract.version}</docker.jpn.args.langsPkg>
+        <docker.jpn.args.langsPkg>tesseract-ocr=${tesseract.version} tesseract-ocr-jpn=${tesseract.lang.version}</docker.jpn.args.langsPkg>
     </properties>
     
     <dependencies>

--- a/distribution/src/main/docker/Dockerfile
+++ b/distribution/src/main/docker/Dockerfile
@@ -1,12 +1,13 @@
-FROM openjdk:15.0.1
+FROM openjdk:15.0.2-jdk-slim-buster
 
 ARG langsPkg
+
 RUN set -ex \
-    && apt update \
-    && apt install -y --no-install-recommends \
-        "gettext-base=0.19.*" \
-        ${langsPkg} \
-    && apt clean \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+    "gettext-base=0.19.*" \
+    ${langsPkg} \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 COPY maven /usr/share/fscrawler


### PR DESCRIPTION
use `openjdk:15.0.2-jdk-slim-buster` as base image

upgrade tesseract package versions to 4.0.0 (hope it doesn't break) the toolchain